### PR TITLE
refactor: `_create_docker_image_names()` を削除

### DIFF
--- a/test/unit/tools/test_generate_docker_image_names.py
+++ b/test/unit/tools/test_generate_docker_image_names.py
@@ -1,7 +1,6 @@
 """`generate_docker_image_names.py` のテスト"""
 
 from tools.generate_docker_image_names import (
-    _create_docker_image_names,
     _generate_docker_image_names,
     _generate_docker_image_tags,
 )
@@ -50,37 +49,6 @@ def test_generate_docker_image_tags_for_release() -> None:
         version=version,
         comma_separated_prefix=comma_separated_prefix,
         with_latest=with_latest,
-    )
-
-    # Test
-    assert image_names == expected_image_names
-
-
-def test_create_docker_image_names() -> None:
-    """Dockerイメージ名を生成できる。"""
-    # Inputs
-    repository = "your-org/your-repo"
-    tags = [
-        "0.22.0",
-        "latest",
-        "cpu-0.22.0",
-        "cpu-latest",
-        "cpu-ubuntu22.04-0.22.0",
-        "cpu-ubuntu22.04-latest",
-    ]
-    # Expects
-    expected_image_names = [
-        "your-org/your-repo:0.22.0",
-        "your-org/your-repo:latest",
-        "your-org/your-repo:cpu-0.22.0",
-        "your-org/your-repo:cpu-latest",
-        "your-org/your-repo:cpu-ubuntu22.04-0.22.0",
-        "your-org/your-repo:cpu-ubuntu22.04-latest",
-    ]
-    # Outputs
-    image_names = _create_docker_image_names(
-        repository=repository,
-        tags=tags,
     )
 
     # Test

--- a/tools/generate_docker_image_names.py
+++ b/tools/generate_docker_image_names.py
@@ -114,52 +114,6 @@ def _generate_docker_image_tags(
     return tags
 
 
-def _create_docker_image_names(
-    repository: str,
-    tags: list[str],
-) -> list[str]:
-    """
-    Dockerイメージ名を作成する。
-
-    Dockerリポジトリ名、Dockerタグ名のリストを受け取り、Dockerイメージ名を配列で返す。
-
-    Parameters
-    ----------
-    repository : str
-        Dockerリポジトリ名
-    tags : list[str]
-        Dockerイメージタグのリスト
-
-    Returns
-    -------
-    list[str]
-        Dockerイメージ名の配列。
-
-    Examples
-    --------
-    >>> _create_docker_image_names(
-    ...     repository="voicevox/voicevox_engine",
-    ...     tags=[
-    ...         "0.22.0-preview.1",
-    ...         "cpu-0.22.0-preview.1",
-    ...         "cpu-ubuntu22.04-0.22.0-preview.1",
-    ...     ],
-    ... )
-    ['voicevox/voicevox_engine:0.22.0-preview.1',
-     'voicevox/voicevox_engine:cpu-0.22.0-preview.1',
-     'voicevox/voicevox_engine:cpu-ubuntu22.04-0.22.0-preview.1']
-    """
-    # 戻り値の配列
-    docker_image_names: list[str] = []
-
-    for tag in tags:
-        # Dockerイメージ名を生成
-        docker_image_name = f"{repository}:{tag}"
-        docker_image_names.append(docker_image_name)
-
-    return docker_image_names
-
-
 def _generate_docker_image_names(
     repository: str,
     version: str,
@@ -192,12 +146,7 @@ def _generate_docker_image_names(
         comma_separated_prefix=comma_separated_prefix,
         with_latest=with_latest,
     )
-    return set(
-        _create_docker_image_names(
-            repository=repository,
-            tags=list(tags),
-        )
-    )
+    return set(map(lambda tag: f"{repository}:{tag}", tags))
 
 
 def main() -> None:


### PR DESCRIPTION
## 内容
https://github.com/VOICEVOX/voicevox_engine/pull/1708 において `_create_docker_image_names()` を削除するリファクタリングを提案します。  

## 関連 Issue
https://github.com/VOICEVOX/voicevox_engine/pull/1708#pullrequestreview-2866720818